### PR TITLE
Cleanups to README and CI

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,5 +1,6 @@
+---
 name: Audit
-on:
+"on":
   push:
     branches:
       - trunk

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,6 @@
+---
 name: CI
-on:
+"on":
   push:
     branches:
       - trunk
@@ -19,8 +20,11 @@ jobs:
       - name: Lint and check formatting with prettier
         run: npx prettier --check '**/*'
 
-      - name: Format markdown with prettier
-        run: npx prettier --prose-wrap always --check '**/*.md'
-
-      - name: Format YAML with prettier
-        run: npx prettier --prose-wrap always --check '**/*.{yaml,yml}'
+      - name: Lint YAML sources with yamllint
+        run: |
+          sudo -H python3 -m pip install --upgrade pip setuptools wheel
+          sudo -H python3 -m pip install --upgrade yamllint
+          yamllint --version
+          echo "Linting YAML sources with yamllint ..."
+          yamllint --strict .
+          echo "OK"

--- a/.github/workflows/repo-labels.yaml
+++ b/.github/workflows/repo-labels.yaml
@@ -1,4 +1,5 @@
-on:
+---
+"on":
   push:
     branches:
       - trunk

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 
 !**/*/
 
+.vscode/
 node_modules/
 target/
 

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,10 @@
+---
+overrides:
+  # Always wrap markdown
+  - files: "*.md"
+    options:
+      proseWrap: always
+  # Preserve wrap for yaml as wrapping make some commands less readable
+  - files: "*.{yaml,yml}"
+    options:
+      proseWrap: preserve

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,11 @@
+---
+extends: default
+
+ignore: |
+  **/node_modules/**/*
+  **/vendor/**
+  **/target/**/*
+
+rules:
+  comments: disable
+  line-length: disable

--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@
 [![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
 [![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
 
-Package Ruby applications to a single static binary using
-[Artichoke](https://github.com/artichoke/artichoke).
+Package Ruby applications to a single static binary using [Artichoke].
 
-Jasper will support building for native and
-[WebAssembly](https://webassembly.org) targets.
+Jasper will support building for native and [WebAssembly] targets.
+
+Jasper is a speculative project and likely will not receive significant
+attention until Artichoke builds for the `wasm32-unknown-unknown` target.
+
+[artichoke]: https://github.com/artichoke/artichoke
+[webassembly]: https://webassembly.org

--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
     }
   },
   "scripts": {
-    "fmt": "npx prettier --write '**/*'",
-    "fmt:all": "npm run fmt && npm run fmt:md && npm run fmt:yaml",
-    "fmt:md": "npx prettier --prose-wrap always --write '**/*.md'",
-    "fmt:yaml": "npx prettier --prose-wrap always --write '**/*.{yaml,yml}'"
+    "fmt": "npx prettier --write '**/*'"
   }
 }


### PR DESCRIPTION
- Add a note to the README about this project's status as speculative
  and unlikely to receive attention in the short term.
- Pull markdown links in README to named anchors for readability.
- Add `.prettierignore` and `.prettierrc.yaml` synced from
  artichoke/artichoke.
- Fixup `package.json` fmt script to use `.prettierrc.yaml`
- Add yamllint to CI / text build.
- Format GitHub Actions workflows to comply with yamllint suggestions.