### PR TITLE
Fix quoting in prettier invocation for fmt npm run script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     }
   },
   "scripts": {
-    "fmt": "npx prettier --write '**/*'"
+    "fmt": "npx prettier --write \"**/*\""
   }
 }


### PR DESCRIPTION
Windows requires the glob to be double quoted.