### PR TITLE
Sync .prettierrc.yaml to format repo labels

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -8,3 +8,6 @@ overrides:
   - files: "*.{yaml,yml}"
     options:
       proseWrap: preserve
+  - files: ".github/labels.{yaml,yml}"
+    options:
+      proseWrap: always


### PR DESCRIPTION
This commit has no effect since this repository has not migrated to `labels.yaml` and `crazy-max/ghaction-github-labeler@v3`.