### PR TITLE
Purge vestigial eslint config from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,14 +21,6 @@
   "devDependencies": {
     "prettier": "^3.4.1"
   },
-  "eslintConfig": {
-    "env": {
-      "browser": true,
-      "commonjs": true,
-      "es6": true,
-      "node": true
-    }
-  },
   "scripts": {
     "fmt": "prettier --write \"**/*\""
   }


### PR DESCRIPTION
This is a copy-paste legacy. This repo does not use eslint. This config is not valid for the latest version of eslint@9.